### PR TITLE
fixed heroku server error on nonmember page navbar link

### DIFF
--- a/public/nonMember.html
+++ b/public/nonMember.html
@@ -17,13 +17,13 @@
 
 <body>
   <nav class="navbar navbar-expand-lg">
-    <a class="navbar-brand" href="/admin">Admin</a>
+    <a class="navbar-brand" href="/">Create User</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav"
       aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="navbarNav">
-          <a class="navbar-nav ml-auto nav-item nav-link" href="/logout">Logout</a>
+          <a class="navbar-nav ml-auto nav-item nav-link" href="/login">Login</a>
     </div>
   </nav>
 


### PR DESCRIPTION
link to admin was throwing server error because no username had been established.   Changing link over to create user page. 
